### PR TITLE
[DMS-74] Implement missing functionality for set

### DIFF
--- a/src/PersistentOrderedSet.mo
+++ b/src/PersistentOrderedSet.mo
@@ -4,6 +4,9 @@
 /// * Runtime: `O(log(n))` worst case cost per insertion, removal, and retrieval operation.
 /// * Space: `O(n)` for storing the entire tree.
 /// `n` denotes the number of elements (i.e. nodes) stored in the tree.
+///
+/// The set operations implementation is derived from:
+/// Tobias Nipkow's "Functional Data Structures and Algorithms", 10: 117-125 (2024).
 
 
 import Map "PersistentOrderedMap";
@@ -135,6 +138,242 @@ module {
     ///
     /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
     public func contains(rbSet : Set<T>, value : T) : Bool = Option.isSome(mapOps.get(rbSet, value));
+
+    /// [Set union](https://en.wikipedia.org/wiki/Union_(set_theory)) operation.
+    ///
+    /// Example:
+    /// ```motoko
+    /// import Set "mo:base/PersistentOrderedSet";
+    /// import Nat "mo:base/Nat";
+    /// import Iter "mo:base/Iter"
+    ///
+    /// let setOps = Set.SetOps<Nat>(Nat.compare);
+    /// let rbSet1 = setOps.fromIter(Iter.fromArray([0, 1, 2]));
+    /// let rbSet2 = setOps.fromIter(Iter.fromArray([2, 3, 4]));
+    ///
+    /// Debug.print(debug_show Iter.toArray(Set.elements(setOps.union(rbSet1, rbSet2))));
+    ///
+    /// // [0, 1, 2, 3, 4]
+    /// ```
+    ///
+    /// Runtime: `O(m * log(n/m + 1))`.
+    /// Space: `O(m * log(n/m + 1))`, where `m` and `n` denote the number of elements
+    /// in the sets, and `m <= n`.
+    public func union(rbSet1 : Set<T>, rbSet2 : Set<T>) : Set<T> {
+      switch (rbSet1, rbSet2) {
+        case (#leaf, rbSet) { rbSet };
+        case (rbSet, #leaf) { rbSet };
+        case (#node (_,l1, (k, v), r1), _) {
+          let (l2, _, r2) = Map.Internal.split(k, rbSet2, compare);
+          Map.Internal.join(union(l1, l2), (k, v), union(r1, r2))
+        };
+      };
+    };
+
+    /// [Set intersection](https://en.wikipedia.org/wiki/Intersection_(set_theory)) operation.
+    ///
+    /// Example:
+    /// ```motoko
+    /// import Set "mo:base/PersistentOrderedSet";
+    /// import Nat "mo:base/Nat";
+    /// import Iter "mo:base/Iter";
+    ///
+    /// let setOps = Set.SetOps<Nat>(Nat.compare);
+    /// let rbSet1 = setOps.fromIter(Iter.fromArray([0, 1, 2]));
+    /// let rbSet2 = setOps.fromIter(Iter.fromArray([1, 2, 3]));
+    ///
+    /// Debug.print(debug_show Iter.toArray(Set.elements(setOps.intersect(rbSet1, rbSet2))));
+    ///
+    /// // [1, 2]
+    /// ```
+    ///
+    /// Runtime: `O(m * log(n/m + 1))`.
+    /// Space: `O(m * log(n/m + 1))`, where `m` and `n` denote the number of elements
+    /// in the sets, and `m <= n`.
+    public func intersect(rbSet1 : Set<T>, rbSet2 : Set<T>) : Set<T> {
+      switch (rbSet1, rbSet2) {
+        case (#leaf, _) { #leaf };
+        case (_, #leaf) { #leaf };
+        case (#node (_, l1, (k, v), r1), _) {
+          let (l2, b2, r2) = Map.Internal.split(k, rbSet2, compare);
+          let l = intersect(l1, l2);
+          let r = intersect(r1, r2);
+          if b2 { Map.Internal.join (l, (k, v), r) }
+          else { Map.Internal.join2(l, r) };
+        };
+      };
+    };
+
+    /// [Set difference](https://en.wikipedia.org/wiki/Difference_(set_theory)).
+    ///
+    /// Example:
+    /// ```motoko
+    /// import Set "mo:base/PersistentOrderedSet";
+    /// import Nat "mo:base/Nat";
+    /// import Iter "mo:base/Iter"
+    ///
+    /// let setOps = Set.SetOps<Nat>(Nat.compare);
+    /// let rbSet1 = setOps.fromIter(Iter.fromArray([0, 1, 2]));
+    /// let rbSet2 = setOps.fromIter(Iter.fromArray([1, 2, 3]));
+    ///
+    /// Debug.print(debug_show Iter.toArray(Set.elements(setOps.diff(rbSet1, rbSet2))));
+    ///
+    /// // [0]
+    /// ```
+    ///
+    /// Runtime: `O(m * log(n/m + 1))`.
+    /// Space: `O(m * log(n/m + 1))`, where `m` and `n` denote the number of elements
+    /// in the sets, and `m <= n`.
+    public func diff(rbSet1 : Set<T>, rbSet2 : Set<T>) : Set<T> {
+      switch (rbSet1, rbSet2) {
+        case (#leaf, _) { #leaf };
+        case (rbSet, #leaf) { rbSet };
+        case (_, (#node(_, l2, (k, _), r2))) {
+          let (l1, _, r1) = Map.Internal.split(k, rbSet1, compare);
+          Map.Internal.join2(diff(l1, l2), diff(r1, r2));
+        }
+      }
+    };
+
+    /// Creates a new Set by applying `f` to each entry in `rbSet`. Each element
+    /// `x` in the old set is transformed into a new entry `x2`, where
+    /// the new value `x2` is created by applying `f` to `x`.
+    /// The result set may be smaller than the original set due to duplicate elements.
+    ///
+    /// Example:
+    /// ```motoko
+    /// import Map "mo:base/PersistentOrderedMap";
+    /// import Nat "mo:base/Nat"
+    /// import Iter "mo:base/Iter"
+    ///
+    /// let setOps = Set.SetOps<Nat>(Nat.compare);
+    /// let rbSet = setOps.fromIter(Iter.fromArray([0, 1, 2, 3]));
+    ///
+    /// func f(x : Nat) : Nat = if (x < 2) { x } else { 0 };
+    ///
+    /// let resSet = setOps.map(rbSet, f);
+    ///
+    /// Debug.print(debug_show(Iter.toArray(Set.elements(resSet))));
+    /// // [0, 1]
+    /// ```
+    ///
+    /// Cost of mapping all the elements:
+    /// Runtime: `O(n)`.
+    /// Space: `O(n)` retained memory
+    /// where `n` denotes the number of elements stored in the set.
+    public func map<T1>(rbSet : Set<T1>, f : T1 -> T) : Set<T> = fromIter(I.map(elements(rbSet), f));
+
+    /// Creates a new map by applying `f` to each element in `rbSet`. For each element
+    /// `x` in the old set, if `f` evaluates to `null`, the element is discarded.
+    /// Otherwise, the entry is transformed into a new entry `x2`, where
+    /// the new value `x2` is the result of applying `f` to `x`.
+    ///
+    /// Example:
+    /// ```motoko
+    /// import Map "mo:base/PersistentOrderedMap";
+    /// import Nat "mo:base/Nat"
+    /// import Iter "mo:base/Iter";
+    ///
+    /// let setOps = Set.SetOps<Nat>(Nat.compare);
+    /// let rbSet = setOps.fromIter(Iter.fromArray([0, 1, 2, 3]));
+    ///
+    /// func f(x : Nat) : ?Nat {
+    ///   if(x == 0) {null}
+    ///   else { ?( x * 2 )}
+    /// };
+    ///
+    /// let newRbSet = setOps.mapFilter(rbSet, f);
+    ///
+    /// Debug.print(debug_show(Iter.toArray(Set.elements(newRbSet))));
+    ///
+    /// // [2, 4, 6]
+    /// ```
+    ///
+    /// Runtime: `O(n)`.
+    /// Space: `O(n)` retained memory plus garbage, see the note below.
+    /// where `n` denotes the number of elements stored in the set and
+    /// assuming that the `compare` function implements an `O(1)` comparison.
+    ///
+    /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
+    public func mapFilter<T1>(rbSet: Set<T1>, f : T1 -> ?T) : Set<T> {
+        var set = #leaf : Set<T>;
+        for(x in elements(rbSet)) {
+          switch(f x){
+            case null {};
+            case (?x2) {
+              set := put(set, x2);
+            }
+          }
+        };
+        set
+    };
+
+    /// Test if `rbSet1` is subset of `rbSet2`.
+    ///
+    /// Example:
+    /// ```motoko
+    /// import Set "mo:base/PersistentOrderedSet";
+    /// import Nat "mo:base/Nat";
+    /// import Iter "mo:base/Iter"
+    ///
+    /// let setOps = Set.SetOps<Nat>(Nat.compare);
+    /// let rbSet1 = setOps.fromIter(Iter.fromArray([1, 2]));
+    /// let rbSet2 = setOps.fromIter(Iter.fromArray([0, 2, 1]));
+    ///
+    /// Debug.print(debug_show setOps.isSubset(rbSet1, rbSet2));
+    ///
+    /// // true
+    /// ```
+    ///
+    /// Runtime: `O(m * log(n))`.
+    /// Space: `O(1)` retained memory plus garbage, see the note below.
+    /// where `m` and `n` denote the number of elements stored in the sets rbSet1 and rbSet2, respectively,
+    /// and assuming that the `compare` function implements an `O(1)` comparison.
+    ///
+    /// Note: Creates `O(m * log(n))` temporary objects that will be collected as garbage.
+    public func isSubset(rbSet1 : Set<T>, rbSet2 : Set<T>) : Bool {
+      if (size(rbSet1) > size(rbSet2)) { return false; };
+      isSubsetHelper(rbSet1, rbSet2)
+    };
+
+    /// Test if two sets are equal.
+    ///
+    /// Example:
+    /// ```motoko
+    /// import Set "mo:base/PersistentOrderedSet";
+    /// import Nat "mo:base/Nat";
+    /// import Iter "mo:base/Iter"
+    ///
+    /// let setOps = Set.SetOps<Nat>(Nat.compare);
+    /// let rbSet1 = setOps.fromIter(Iter.fromArray([0, 2, 1]));
+    /// let rbSet2 = setOps.fromIter(Iter.fromArray([1, 2]));
+    ///
+    /// Debug.print(debug_show setOps.equals(rbSet1, rbSet1));
+    /// Debug.print(debug_show setOps.equals(rbSet1, rbSet2));
+    ///
+    /// // true
+    /// // false
+    /// ```
+    ///
+    /// Runtime: `O(m * log(n))`.
+    /// Space: `O(1)` retained memory plus garbage, see the note below.
+    /// where `m` and `n` denote the number of elements stored in the sets rbSet1 and rbSet2, respectively,
+    /// and assuming that the `compare` function implements an `O(1)` comparison.
+    ///
+    /// Note: Creates `O(m * log(n))` temporary objects that will be collected as garbage.
+    public func equals (rbSet1 : Set<T>, rbSet2 : Set<T>) : Bool {
+      if (size(rbSet1) != size(rbSet2)) { return false; };
+      isSubsetHelper(rbSet1, rbSet2)
+    };
+
+    func isSubsetHelper(rbSet1 : Set<T>, rbSet2 : Set<T>) : Bool {
+      for (x in elements(rbSet1)) {
+        if (not (contains(rbSet2, x))) {
+          return false;
+        }
+      };
+      return true;
+    };
   };
 
   /// Returns an Iterator (`Iter`) over the elements of the set.
@@ -175,7 +414,7 @@ module {
   /// // 0
   /// ```
   ///
-  /// Cost of empty map creation
+  /// Cost of empty set creation
   /// Runtime: `O(1)`.
   /// Space: `O(1)`
   public func empty<T>() : Set<T> = Map.empty<T, ()>();
@@ -277,5 +516,27 @@ module {
       base,
       func (x : T , _ : (), acc : Accum) : Accum { combine(x, acc) }
     )
+  };
+
+  /// Test if set is empty.
+  ///
+  /// Example:
+  /// ```motoko
+  /// import Set "mo:base/PersistentOrderedSet";
+  ///
+  /// let rbSet = Set.empty<Nat>();
+  ///
+  /// Debug.print(debug_show(Set.isEmpty(rbSet)));
+  ///
+  /// // true
+  /// ```
+  ///
+  /// Runtime: `O(1)`.
+  /// Space: `O(1)`
+  public func isEmpty<T> (rbSet : Set<T>) : Bool {
+    switch rbSet {
+      case (#leaf) { true };
+      case _ { false };
+    };
   };
 }

--- a/test/PersistentOrderedSet.test.mo
+++ b/test/PersistentOrderedSet.test.mo
@@ -95,6 +95,16 @@ func clear(initialRbSet : Set.Set<Nat>) : Set.Set<Nat> {
   rbSet
 };
 
+func add1(x : Nat) : Nat { x + 1 };
+
+func ifElemLessThan(threshold : Nat, f : Nat -> Nat) : Nat -> ?Nat
+  = func (x) {
+    if(x < threshold)
+      ?f(x)
+    else null
+  };
+
+
 /* --------------------------------------- */
 
 var buildTestSet = func() : Set.Set<Nat> {
@@ -134,6 +144,21 @@ run(
         "empty left fold",
         Set.foldLeft(buildTestSet(), "", concatenateKeys),
         M.equals(T.text(""))
+      ),
+      test(
+        "traverse empty set",
+        natSetOps.map(buildTestSet(), add1),
+        SetMatcher([])
+      ),
+      test(
+        "empty map filter",
+        natSetOps.mapFilter(buildTestSet(), ifElemLessThan(0, add1)),
+        SetMatcher([])
+      ),
+      test(
+        "is empty",
+        Set.isEmpty(buildTestSet()),
+        M.equals(T.bool(true))
       ),
     ]
   )
@@ -185,6 +210,26 @@ run(
         "left fold",
         Set.foldLeft(buildTestSet(), "", concatenateKeys),
         M.equals(T.text("0"))
+      ),
+      test(
+        "traverse set",
+        natSetOps.map(buildTestSet(), add1),
+        SetMatcher([1])
+      ),
+      test(
+        "map filter/filter all",
+        natSetOps.mapFilter(buildTestSet(), ifElemLessThan(0, add1)),
+        SetMatcher([])
+      ),
+      test(
+        "map filter/no filer",
+        natSetOps.mapFilter(buildTestSet(), ifElemLessThan(1, add1)),
+        SetMatcher([1])
+      ),
+      test(
+        "is empty",
+        Set.isEmpty(buildTestSet()),
+        M.equals(T.bool(false))
       ),
     ]
   )
@@ -239,6 +284,36 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] =
       "left fold",
       Set.foldLeft(buildTestSet(), "", concatenateKeys),
       M.equals(T.text("012"))
+    ),
+    test(
+      "traverse set",
+      natSetOps.map(buildTestSet(), add1),
+      SetMatcher([1, 2, 3])
+    ),
+    test(
+      "traverse set/reshape",
+      natSetOps.map(buildTestSet(), func (x : Nat) : Nat {5}),
+      SetMatcher([5])
+    ),
+    test(
+      "map filter/filter all",
+      natSetOps.mapFilter(buildTestSet(), ifElemLessThan(0, add1)),
+      SetMatcher([])
+    ),
+    test(
+      "map filter/filter one",
+      natSetOps.mapFilter(buildTestSet(), ifElemLessThan(1, add1)),
+      SetMatcher([1])
+    ),
+    test(
+      "map filter/no filer",
+      natSetOps.mapFilter(buildTestSet(), ifElemLessThan(3, add1)),
+      SetMatcher([1, 2, 3])
+    ),
+    test(
+      "is empty",
+      Set.isEmpty(buildTestSet()),
+      M.equals(T.bool(false))
     ),
   ];
 
@@ -313,6 +388,177 @@ run(
         },
         SetMatcher([0, 2])
       )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+let buildTestSet012 = func() : Set.Set<Nat> {
+  var rbSet = Set.empty<Nat>();
+  rbSet := insert(rbSet, 0);
+  rbSet := insert(rbSet, 1);
+  rbSet := insert(rbSet, 2);
+  rbSet
+};
+
+let buildTestSet01 = func() : Set.Set<Nat> {
+  var rbSet = Set.empty<Nat>();
+  rbSet := insert(rbSet, 0);
+  rbSet := insert(rbSet, 1);
+  rbSet
+};
+
+let buildTestSet234 = func() : Set.Set<Nat> {
+  var rbSet = Set.empty<Nat>();
+  rbSet := insert(rbSet, 2);
+  rbSet := insert(rbSet, 3);
+  rbSet := insert(rbSet, 4);
+  rbSet
+};
+
+let buildTestSet345 = func() : Set.Set<Nat> {
+  var rbSet = Set.empty<Nat>();
+  rbSet := insert(rbSet, 5);
+  rbSet := insert(rbSet, 3);
+  rbSet := insert(rbSet, 4);
+  rbSet
+};
+
+run(
+  suite(
+    "set operations",
+    [
+      test(
+        "subset/subset of itself",
+        natSetOps.isSubset(buildTestSet012(), buildTestSet012()),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "subset/empty set is subset of itself",
+        natSetOps.isSubset(Set.empty<Nat>(), Set.empty<Nat>()),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "subset/empty set is subset of another set",
+        natSetOps.isSubset(Set.empty<Nat>(), buildTestSet012()),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "subset/subset",
+        natSetOps.isSubset(buildTestSet01(), buildTestSet012()),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "subset/not subset",
+        natSetOps.isSubset(buildTestSet012(), buildTestSet01()),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "equals/empty set",
+        natSetOps.equals(Set.empty<Nat>(), Set.empty<Nat>()),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "equals/equals",
+        natSetOps.equals(buildTestSet012(), buildTestSet012()),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "equals/not equals",
+        natSetOps.equals(buildTestSet012(), buildTestSet01()),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "union/empty set",
+        natSetOps.union(Set.empty<Nat>(), Set.empty<Nat>()),
+        SetMatcher([])
+      ),
+      test(
+        "union/union with empty set",
+        natSetOps.union(buildTestSet012(), Set.empty<Nat>()),
+        SetMatcher([0, 1, 2])
+      ),
+      test(
+        "union/union with itself",
+        natSetOps.union(buildTestSet012(), buildTestSet012()),
+        SetMatcher([0, 1, 2])
+      ),
+      test(
+        "union/union with subset",
+        natSetOps.union(buildTestSet012(), buildTestSet01()),
+        SetMatcher([0, 1, 2])
+      ),
+      test(
+        "union/union expand",
+        natSetOps.union(buildTestSet012(), buildTestSet234()),
+        SetMatcher([0, 1, 2, 3, 4])
+      ),
+      test(
+        "intersect/empty set",
+        natSetOps.intersect(Set.empty<Nat>(), Set.empty<Nat>()),
+        SetMatcher([])
+      ),
+      test(
+        "intersect/intersect with empty set",
+        natSetOps.intersect(buildTestSet012(), Set.empty<Nat>()),
+        SetMatcher([])
+      ),
+      test(
+        "intersect/intersect with itself",
+        natSetOps.intersect(buildTestSet012(), buildTestSet012()),
+        SetMatcher([0, 1, 2])
+      ),
+      test(
+        "intersect/intersect with subset",
+        natSetOps.intersect(buildTestSet012(), buildTestSet01()),
+        SetMatcher([0, 1])
+      ),
+      test(
+        "intersect/intersect",
+        natSetOps.intersect(buildTestSet012(), buildTestSet234()),
+        SetMatcher([2])
+      ),
+      test(
+        "intersect/no intersection",
+        natSetOps.intersect(buildTestSet012(), buildTestSet345()),
+        SetMatcher([])
+      ),
+      test(
+        "diff/empty set",
+        natSetOps.diff(Set.empty<Nat>(), Set.empty<Nat>()),
+        SetMatcher([])
+      ),
+      test(
+        "diff/diff with empty set",
+        natSetOps.diff(buildTestSet012(), Set.empty<Nat>()),
+        SetMatcher([0, 1, 2])
+      ),
+      test(
+        "diff/diff with empty set 2",
+        natSetOps.diff(Set.empty<Nat>(), buildTestSet012()),
+        SetMatcher([])
+      ),
+      test(
+        "diff/diff with subset",
+        natSetOps.diff(buildTestSet012(), buildTestSet01()),
+        SetMatcher([2])
+      ),
+      test(
+        "diff/diff with subset 2",
+        natSetOps.diff(buildTestSet01(), buildTestSet012()),
+        SetMatcher([])
+      ),
+      test(
+        "diff/diff",
+        natSetOps.diff(buildTestSet012(), buildTestSet234()),
+        SetMatcher([0, 1])
+      ),
+      test(
+        "diff/diff no intersection",
+        natSetOps.diff(buildTestSet012(), buildTestSet345()),
+        SetMatcher([0, 1, 2])
+      ),
     ]
   )
 );


### PR DESCRIPTION
Add following functions:

union(rbSet1 : Set<T>, rbSet2 : Set<T>) : Set<T>
intersect(rbSet1 : Set<T>, rbSet2 : Set<T>) : Set<T>
diff(rbSet1 : Set<T>, rbSet2 : Set<T>) : Set<T>
map<T1>(rbSet : Set<T1>, f : T1 -> T) : Set<T>
mapFilter<T1>(rbSet: Set<T1>, f : T1 -> ?T) : Set<T>
isSubset(rbSet1 : Set<T>, rbSet2 : Set<T>) : Bool
equals (rbSet1 : Set<T>, rbSet2 : Set<T>) : Bool
isEmpty<T> (rbSet : Set<T>) : Bool

Add tests for the functions above.