### PR TITLE
[DMS-68] Implement mapFilter using foldLeft instad of iter

### DIFF
--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -602,19 +602,15 @@ module {
     };
 
     public func mapFilter<K, V1, V2>(t : Map<K, V1>, compare : (K, K) -> O.Order, f : (K, V1) -> ?V2) : Map<K, V2>{
-      var map = #leaf : Map<K, V2>;
-      for(kv in iter(t, #fwd))
-      {
-        switch(f kv){
-          case null {};
-          case (?v1) {
-            // The keys still are monotonic, so we can
-            // merge trees using `append` and avoid compare here
-            map := put(map, compare, kv.0, v1);
+      func combine(key : K, value1 : V1, acc : Map<K, V2>) : Map<K, V2> {
+        switch (f(key, value1)){
+          case null { acc };
+          case (?value2) {
+            put(acc, compare, key, value2)
           }
         }
       };
-      map
+      foldLeft(t, #leaf, combine)
     };
 
     public func get<K, V>(t : Map<K, V>, compare : (K, K) -> O.Order, x : K) : ?V {


### PR DESCRIPTION
In comparison with #12 

| |size|foldLeft|foldRight|mapfilter|map|
|--:|--:|--:|--:|--:|--:|
|persistentmap|100|18_597|18_509|97_613|29_443|
|persistentmap_baseline|100|18_597|18_509|157_384|29_048|
|persistentmap|1000|154_997|153_509|1_763_344|258_079|
|persistentmap_baseline|1000|154_997|153_509|2_355_770|1_332_475|
|persistentmap|10000|1_521_863|1_503_632|36_132_684|2_544_359|
|persistentmap_baseline|10000|1_521_863|1_503_632|42_053_834|2_544_359|
|persistentmap|100000|15_198_893|15_004_493|434_003_881|132_210_500|
|persistentmap_baseline|100000|15_198_893|15_004_493|493_211_693|132_210_500|
|persistentmap|1000000|151_997_225|150_013_513|5_045_781_583|1_322_035_748|
|persistentmap_baseline|1000000|151_997_225|150_013_513|5_637_834_835|1_322_035_748|
