### PR TITLE
[DMS-68] Reuse iteration code and parametrize it with map walking function

### DIFF
--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -324,30 +324,39 @@ module {
   ///
   /// Note: Full map iteration creates `O(n)` temporary objects that will be collected as garbage.
   public func iter<K, V>(rbMap : Map<K, V>, direction : Direction) : I.Iter<(K, V)> {
-    object {
-      var trees : IterRep<K, V> = ?(#tr(rbMap), null);
-      public func next() : ?(K, V) {
-        switch (direction, trees) {
-          case (_, null) { null };
-          case (_, ?(#tr(#leaf), ts)) {
+    let turnLeftFirst : MapTraverser<K, V>
+     = func (l, xy, r, ts) { ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts))) };
+
+    let turnRightFirst : MapTraverser<K, V>
+     = func (l, xy, r, ts) { ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts))) };
+
+    switch direction {
+      case (#fwd) IterMap(rbMap, turnLeftFirst);
+      case (#bwd) IterMap(rbMap, turnRightFirst)
+    }
+  };
+
+  type MapTraverser<K, V> = (Map<K, V>, (K, V), Map<K, V>, IterRep<K, V>) -> IterRep<K, V>;
+
+  class IterMap<K, V>(rbMap : Map<K, V>, mapTraverser : MapTraverser<K, V>) {
+    var trees : IterRep<K, V> = ?(#tr(rbMap), null);
+    public func next() : ?(K, V) {
+        switch (trees) {
+          case (null) { null };
+          case (?(#tr(#leaf), ts)) {
             trees := ts;
             next()
           };
-          case (_, ?(#xy(xy), ts)) {
+          case (?(#xy(xy), ts)) {
             trees := ts;
             ?xy
-          }; // TODO: Let's float-out case on direction
-          case (#fwd, ?(#tr(#node(_, l, xy, r)), ts)) {
-            trees := ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts)));
-            next()
           };
-          case (#bwd, ?(#tr(#node(_, l, xy, r)), ts)) {
-            trees := ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts)));
+          case (?(#tr(#node(_, l, xy, r)), ts)) {
+            trees := mapTraverser(l, xy, r, ts);
             next()
           }
         }
       }
-    }
   };
 
   /// Returns an Iterator (`Iter`) over the key-value pairs in the map.


### PR DESCRIPTION
In comparison with #10 

| |size|foldLeft|foldRight|mapfilter|map|
|--:|--:|--:|--:|--:|--:|
|persistentmap|100|80_886|80_902|158_806|29_048|
|persistentmap_baseline|100|79_472|79_588|157_392|29_048|
|persistentmap|1000|775_681|775_592|3_444_270|257_766|
|persistentmap_baseline|1000|761_667|762_619|3_430_215|257_766|
|persistentmap|10000|7_722_849|18_400_346|42_193_897|2_544_359|
|persistentmap_baseline|10000|7_582_712|18_270_414|42_053_473|2_544_359|
|persistentmap|100000|184_009_591|183_915_359|494_611_920|132_210_500|
|persistentmap_baseline|100000|182_610_151|182_615_427|493_211_373|132_210_500|
|persistentmap|1000000|1_840_053_143|1_839_070_132|5_651_838_547|1_322_035_748|
|persistentmap_baseline|1000000|1_826_050_546|1_826_067_207|5_637_839_066|1_322_035_748|
