### PR TITLE
[DMS-68] Deduplicate branches that are the same for red and black nodes

### DIFF
--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -561,18 +561,15 @@ module {
     combine : (Key, Value, Accum) -> Accum
   ) : Accum
   {
+    func goInside(l : Map<Key, Value>, k : Key, v : Value, r : Map<Key, Value>) : Accum {
+      let left = foldLeft(l, base, combine);
+      let middle = combine(k, v, left);
+      foldLeft(r, middle, combine)
+    };
     switch (rbMap) {
       case (#leaf) { base };
-      case (#red(l, (k, v), r)) {
-        let left = foldLeft(l, base, combine);
-        let middle = combine(k, v, left);
-        foldLeft(r, middle, combine)
-      };
-      case (#black(l, (k, v), r)) {
-        let left = foldLeft(l, base, combine);
-        let middle = combine(k, v, left);
-        foldLeft(r, middle, combine)
-      }
+      case (#red(l, (k, v), r)) { goInside(l, k, v, r) };
+      case (#black(l, (k, v), r)) { goInside(l, k, v, r) }
     }
   };
 
@@ -609,18 +606,15 @@ module {
     combine : (Key, Value, Accum) -> Accum
   ) : Accum
   {
+    func goInside(l : Map<Key, Value>, k : Key, v : Value, r : Map<Key, Value>) : Accum {
+        let right = foldRight(r, base, combine);
+        let middle = combine(k, v, right);
+        foldRight(l, middle, combine)
+    };
     switch (rbMap) {
       case (#leaf) { base };
-      case (#red(l, (k, v), r)) {
-        let right = foldRight(r, base, combine);
-        let middle = combine(k, v, right);
-        foldRight(l, middle, combine)
-      };
-      case (#black(l, (k, v), r)) {
-        let right = foldRight(r, base, combine);
-        let middle = combine(k, v, right);
-        foldRight(l, middle, combine)
-      }
+      case (#red(l, (k, v), r)) { goInside(l, k, v, r) };
+      case (#black(l, (k, v), r)) { goInside(l, k, v, r) }
     }
   };
 
@@ -649,22 +643,17 @@ module {
     };
 
     public func get<K, V>(t : Map<K, V>, compare : (K, K) -> O.Order, x : K) : ?V {
+      func goInside(l : Map<K, V>, xy : (K, V), r : Map<K, V>) : ?V {
+        switch (compare(x, xy.0)) {
+            case (#less) { get(l, compare, x) };
+            case (#equal) { ?xy.1 };
+            case (#greater) { get(r, compare, x) }
+          }
+      };
       switch t {
         case (#leaf) { null };
-        case (#red(l, xy, r)) {
-          switch (compare(x, xy.0)) {
-            case (#less) { get(l, compare, x) };
-            case (#equal) { ?xy.1 };
-            case (#greater) { get(r, compare, x) }
-          }
-        };
-        case (#black(l, xy, r)) {
-          switch (compare(x, xy.0)) {
-            case (#less) { get(l, compare, x) };
-            case (#equal) { ?xy.1 };
-            case (#greater) { get(r, compare, x) }
-          }
-        }
+        case (#red(l, xy, r)) { goInside(l, xy, r) };
+        case (#black(l, xy, r)) { goInside(l, xy, r) }
       }
     };
 

--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -324,27 +324,49 @@ module {
   ///
   /// Note: Full map iteration creates `O(n)` temporary objects that will be collected as garbage.
   public func iter<K, V>(rbMap : Map<K, V>, direction : Direction) : I.Iter<(K, V)> {
-    object {
-      var trees : IterRep<K, V> = ?(#tr(rbMap), null);
-      public func next() : ?(K, V) {
-        switch (direction, trees) {
-          case (_, null) { null };
-          case (_, ?(#tr(#leaf), ts)) {
-            trees := ts;
-            next()
-          };
-          case (_, ?(#xy(xy), ts)) {
-            trees := ts;
-            ?xy
-          }; // TODO: Let's float-out case on direction
-          case (#fwd, ?(#tr(#node(_, l, xy, r)), ts)) {
-            trees := ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts)));
-            next()
-          };
-          case (#bwd, ?(#tr(#node(_, l, xy, r)), ts)) {
-            trees := ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts)));
-            next()
-          }
+    switch direction {
+      case (#fwd) { iterForward(rbMap) };
+      case (#bwd) { iterBackward(rbMap) }
+    }
+  };
+
+  func iterForward<K, V>(rbMap : Map<K, V>) : I.Iter<(K, V)> = object {
+    var trees : IterRep<K, V> = ?(#tr(rbMap), null);
+    public func next() : ?(K, V) {
+      switch (trees) {
+        case (null) { null };
+        case (?(#tr(#leaf), ts)) {
+          trees := ts;
+          next()
+        };
+        case (?(#xy(xy), ts)) {
+          trees := ts;
+          ?xy
+        };
+        case (?(#tr(#node(_, l, xy, r)), ts)) {
+          trees := ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts)));
+          next()
+        }
+      }
+    }
+  };
+
+  func iterBackward<K, V>(rbMap : Map<K, V>) : I.Iter<(K, V)> = object {
+    var trees : IterRep<K, V> = ?(#tr(rbMap), null);
+    public func next() : ?(K, V) {
+      switch (trees) {
+        case (null) { null };
+        case (?(#tr(#leaf), ts)) {
+          trees := ts;
+          next()
+        };
+        case (?(#xy(xy), ts)) {
+          trees := ts;
+          ?xy
+        };
+        case (?(#tr(#node(_, l, xy, r)), ts)) {
+          trees := ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts)));
+          next()
         }
       }
     }

--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -38,14 +38,12 @@ import O "Order";
 
 module {
 
-  /// Node color: Either red (`#R`) or black (`#B`).
-  public type Color = { #R; #B };
-
   /// Red-black tree of nodes with key-value entries, ordered by the keys.
   /// The keys have the generic type `K` and the values the generic type `V`.
   /// Leaves are considered implicitly black.
   public type Map<K, V> = {
-    #node : (Color, Map<K, V>, (K, V), Map<K, V>);
+    #red : (Map<K, V>, (K, V), Map<K, V>);
+    #black : (Map<K, V>, (K, V), Map<K, V>);
     #leaf
   };
 
@@ -343,7 +341,11 @@ module {
           trees := ts;
           ?xy
         };
-        case (?(#tr(#node(_, l, xy, r)), ts)) {
+        case (?(#tr(#red(l, xy, r)), ts)) {
+          trees := ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts)));
+          next()
+        };
+        case (?(#tr(#black(l, xy, r)), ts)) {
           trees := ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts)));
           next()
         }
@@ -364,7 +366,11 @@ module {
           trees := ts;
           ?xy
         };
-        case (?(#tr(#node(_, l, xy, r)), ts)) {
+        case (?(#tr(#red(l, xy, r)), ts)) {
+          trees := ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts)));
+          next()
+        };
+        case (?(#tr(#black(l, xy, r)), ts)) {
           trees := ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts)));
           next()
         }
@@ -480,8 +486,11 @@ module {
     func mapRec(m : Map<K, V1>) : Map<K, V2> {
       switch m {
         case (#leaf) { #leaf };
-        case (#node(c, l, xy, r)) {
-          #node(c, mapRec l, (xy.0, f xy), mapRec r) // TODO: try destination-passing style to avoid non tail-call recursion
+        case (#red(l, xy, r)) {
+          #red(mapRec l, (xy.0, f xy), mapRec r)
+        };
+        case (#black(l, xy, r)) {
+          #black(mapRec l, (xy.0, f xy), mapRec r)
         };
       }
     };
@@ -510,7 +519,10 @@ module {
   public func size<K, V>(t : Map<K, V>) : Nat {
     switch t {
       case (#leaf) { 0 };
-      case (#node(_, l, _, r)) {
+      case (#red(l, _, r)) {
+        size(l) + size(r) + 1
+      };
+      case (#black(l, _, r)) {
         size(l) + size(r) + 1
       }
     }
@@ -551,7 +563,12 @@ module {
   {
     switch (rbMap) {
       case (#leaf) { base };
-      case (#node(_, l, (k, v), r)) {
+      case (#red(l, (k, v), r)) {
+        let left = foldLeft(l, base, combine);
+        let middle = combine(k, v, left);
+        foldLeft(r, middle, combine)
+      };
+      case (#black(l, (k, v), r)) {
         let left = foldLeft(l, base, combine);
         let middle = combine(k, v, left);
         foldLeft(r, middle, combine)
@@ -594,7 +611,12 @@ module {
   {
     switch (rbMap) {
       case (#leaf) { base };
-      case (#node(_, l, (k, v), r)) {
+      case (#red(l, (k, v), r)) {
+        let right = foldRight(r, base, combine);
+        let middle = combine(k, v, right);
+        foldRight(l, middle, combine)
+      };
+      case (#black(l, (k, v), r)) {
         let right = foldRight(r, base, combine);
         let middle = combine(k, v, right);
         foldRight(l, middle, combine)
@@ -629,7 +651,14 @@ module {
     public func get<K, V>(t : Map<K, V>, compare : (K, K) -> O.Order, x : K) : ?V {
       switch t {
         case (#leaf) { null };
-        case (#node(_c, l, xy, r)) {
+        case (#red(l, xy, r)) {
+          switch (compare(x, xy.0)) {
+            case (#less) { get(l, compare, x) };
+            case (#equal) { ?xy.1 };
+            case (#greater) { get(r, compare, x) }
+          }
+        };
+        case (#black(l, xy, r)) {
           switch (compare(x, xy.0)) {
             case (#less) { get(l, compare, x) };
             case (#equal) { ?xy.1 };
@@ -641,8 +670,8 @@ module {
 
     func redden<K, V>(t : Map<K, V>) : Map<K, V> {
       switch t {
-        case (#node (#B, l, xy, r)) {
-          (#node (#R, l, xy, r))
+        case (#black (l, xy, r)) {
+          (#red (l, xy, r))
         };
         case _ {
           Debug.trap "RBTree.red"
@@ -652,44 +681,40 @@ module {
 
     func lbalance<K,V>(left : Map<K, V>, xy : (K,V), right : Map<K, V>) : Map<K,V> {
       switch (left, right) {
-        case (#node(#R, #node(#R, l1, xy1, r1), xy2, r2), r) {
-          #node(
-            #R,
-            #node(#B, l1, xy1, r1),
+        case (#red(#red(l1, xy1, r1), xy2, r2), r) {
+          #red(
+            #black(l1, xy1, r1),
             xy2,
-            #node(#B, r2, xy, r))
+            #black(r2, xy, r))
         };
-        case (#node(#R, l1, xy1, #node(#R, l2, xy2, r2)), r) {
-          #node(
-            #R,
-            #node(#B, l1, xy1, l2),
+        case (#red(l1, xy1, #red(l2, xy2, r2)), r) {
+          #red(
+            #black(l1, xy1, l2),
             xy2,
-            #node(#B, r2, xy, r))
+            #black(r2, xy, r))
         };
         case _ {
-          #node(#B, left, xy, right)
+          #black(left, xy, right)
         }
       }
     };
 
     func rbalance<K,V>(left : Map<K, V>, xy : (K,V), right : Map<K, V>) : Map<K,V> {
       switch (left, right) {
-        case (l, #node(#R, l1, xy1, #node(#R, l2, xy2, r2))) {
-          #node(
-            #R,
-            #node(#B, l, xy, l1),
+        case (l, #red(l1, xy1, #red(l2, xy2, r2))) {
+          #red(
+            #black(l, xy, l1),
             xy1,
-            #node(#B, l2, xy2, r2))
+            #black(l2, xy2, r2))
         };
-        case (l, #node(#R, #node(#R, l1, xy1, r1), xy2, r2)) {
-          #node(
-            #R,
-            #node(#B, l, xy, l1),
+        case (l, #red(#red(l1, xy1, r1), xy2, r2)) {
+          #red(
+            #black(l, xy, l1),
             xy1,
-            #node(#B, r1, xy2, r2))
+            #black(r1, xy2, r2))
         };
         case _ {
-          #node(#B, left, xy, right)
+          #black(left, xy, right)
         };
       }
     };
@@ -707,9 +732,9 @@ module {
       func ins(tree : Map<K,V>) : Map<K,V> {
         switch tree {
           case (#leaf) {
-            #node(#R, #leaf, (key,val), #leaf)
+            #red(#leaf, (key,val), #leaf)
           };
-          case (#node(#B, left, xy, right)) {
+          case (#black(left, xy, right)) {
             switch (compare (key, xy.0)) {
               case (#less) {
                 lbalance(ins left, xy, right)
@@ -719,29 +744,29 @@ module {
               };
               case (#equal) {
                 let newVal = onClash({ new = val; old = xy.1 });
-                #node(#B, left, (key,newVal), right)
+                #black(left, (key,newVal), right)
               }
             }
           };
-          case (#node(#R, left, xy, right)) {
+          case (#red(left, xy, right)) {
             switch (compare (key, xy.0)) {
               case (#less) {
-                #node(#R, ins left, xy, right)
+                #red(ins left, xy, right)
               };
               case (#greater) {
-                #node(#R, left, xy, ins right)
+                #red(left, xy, ins right)
               };
               case (#equal) {
                 let newVal = onClash { new = val; old = xy.1 };
-                #node(#R, left, (key,newVal), right)
+                #red(left, (key,newVal), right)
               }
             }
           }
         };
       };
       switch (ins m) {
-        case (#node(#R, left, xy, right)) {
-          #node(#B, left, xy, right);
+        case (#red(left, xy, right)) {
+          #black(left, xy, right);
         };
         case other { other };
       };
@@ -774,19 +799,18 @@ module {
 
     func balLeft<K,V>(left : Map<K, V>, xy : (K,V), right : Map<K, V>) : Map<K,V> {
       switch (left, right) {
-        case (#node(#R, l1, xy1, r1), r) {
-          #node(
-            #R,
-            #node(#B, l1, xy1, r1),
+        case (#red(l1, xy1, r1), r) {
+          #red(
+            #black(l1, xy1, r1),
             xy,
             r)
         };
-        case (_, #node(#B, l2, xy2, r2)) {
-          rbalance(left, xy, #node(#R, l2, xy2, r2))
+        case (_, #black(l2, xy2, r2)) {
+          rbalance(left, xy, #red(l2, xy2, r2))
         };
-        case (_, #node(#R, #node(#B, l2, xy2, r2), xy3, r3)) {
-          #node(#R,
-            #node(#B, left, xy, l2),
+        case (_, #red(#black(l2, xy2, r2), xy3, r3)) {
+          #red(
+            #black(left, xy, l2),
             xy2,
             rbalance(r2, xy3, redden r3))
         };
@@ -796,20 +820,20 @@ module {
 
     func balRight<K,V>(left : Map<K, V>, xy : (K,V), right : Map<K, V>) : Map<K,V> {
       switch (left, right) {
-        case (l, #node(#R, l1, xy1, r1)) {
-          #node(#R,
+        case (l, #red(l1, xy1, r1)) {
+          #red(
             l,
             xy,
-            #node(#B, l1, xy1, r1))
+            #black(l1, xy1, r1))
         };
-        case (#node(#B, l1, xy1, r1), r) {
-          lbalance(#node(#R, l1, xy1, r1), xy, r);
+        case (#black(l1, xy1, r1), r) {
+          lbalance(#red(l1, xy1, r1), xy, r);
         };
-        case (#node(#R, l1, xy1, #node(#B, l2, xy2, r2)), r3) {
-          #node(#R,
+        case (#red(l1, xy1, #black(l2, xy2, r2)), r3) {
+          #red(
             lbalance(redden l1, xy1, l2),
             xy2,
-            #node(#B, r2, xy, r3))
+            #black(r2, xy, r3))
         };
         case _ { Debug.trap "balRight" };
       }
@@ -819,40 +843,39 @@ module {
       switch (left, right) {
         case (#leaf,  _) { right };
         case (_,  #leaf) { left };
-        case (#node (#R, l1, xy1, r1),
-              #node (#R, l2, xy2, r2)) {
+        case (#red (l1, xy1, r1),
+              #red (l2, xy2, r2)) {
           switch (append (r1, l2)) {
-            case (#node (#R, l3, xy3, r3)) {
-              #node(
-                #R,
-                #node(#R, l1, xy1, l3),
+            case (#red (l3, xy3, r3)) {
+              #red(
+                #red(l1, xy1, l3),
                 xy3,
-                #node(#R, r3, xy2, r2))
+                #red(r3, xy2, r2))
             };
             case r1l2 {
-              #node(#R, l1, xy1, #node(#R, r1l2, xy2, r2))
+              #red(l1, xy1, #red(r1l2, xy2, r2))
             }
           }
         };
-        case (t1, #node(#R, l2, xy2, r2)) {
-          #node(#R, append(t1, l2), xy2, r2)
+        case (t1, #red(l2, xy2, r2)) {
+          #red(append(t1, l2), xy2, r2)
         };
-        case (#node(#R, l1, xy1, r1), t2) {
-          #node(#R, l1, xy1, append(r1, t2))
+        case (#red(l1, xy1, r1), t2) {
+          #red(l1, xy1, append(r1, t2))
         };
-        case (#node(#B, l1, xy1, r1), #node (#B, l2, xy2, r2)) {
+        case (#black(l1, xy1, r1), #black (l2, xy2, r2)) {
           switch (append (r1, l2)) {
-            case (#node (#R, l3, xy3, r3)) {
-              #node(#R,
-                #node(#B, l1, xy1, l3),
+            case (#red (l3, xy3, r3)) {
+              #red(
+                #black(l1, xy1, l3),
                 xy3,
-                #node(#B, r3, xy2, r2))
+                #black(r3, xy2, r2))
             };
             case r1l2 {
               balLeft (
                 l1,
                 xy1,
-                #node(#B, r1l2, xy2, r2)
+                #black(r1l2, xy2, r2)
               )
             }
           }
@@ -870,22 +893,22 @@ module {
           case (#less) {
             let newLeft = del left;
             switch left {
-              case (#node(#B, _, _, _)) {
+              case (#black(_, _, _)) {
                 balLeft(newLeft, xy, right)
               };
               case _ {
-                #node(#R, newLeft, xy, right)
+                #red(newLeft, xy, right)
               }
             }
           };
           case (#greater) {
             let newRight = del right;
             switch right {
-              case (#node(#B, _, _, _)) {
+              case (#black(_, _, _)) {
                 balRight(left, xy, newRight)
               };
               case _ {
-                #node(#R, left, xy, newRight)
+                #red(left, xy, newRight)
               }
             }
           };
@@ -900,14 +923,17 @@ module {
           case (#leaf) {
             tree
           };
-          case (#node(_, left, xy, right)) {
+          case (#red(left, xy, right)) {
+            delNode(left, xy, right)
+          };
+          case (#black(left, xy, right)) {
             delNode(left, xy, right)
           }
         };
       };
       switch (del(tree)) {
-        case (#node(#R, left, xy, right)) {
-          (#node(#B, left, xy, right), y0);
+        case (#red(left, xy, right)) {
+          (#black(left, xy, right), y0);
         };
         case other { (other, y0) };
       };

--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -549,11 +549,14 @@ module {
     combine : (Key, Value, Accum) -> Accum
   ) : Accum
   {
-    var acc = base;
-    for(val in iter(rbMap, #fwd)){
-      acc := combine(val.0, val.1, acc);
-    };
-    acc
+    switch (rbMap) {
+      case (#leaf) { base };
+      case (#node(_, l, (k, v), r)) {
+        let left = foldLeft(l, base, combine);
+        let middle = combine(k, v, left);
+        foldLeft(r, middle, combine)
+      }
+    }
   };
 
   /// Collapses the elements in `rbMap` into a single value by starting with `base`
@@ -589,11 +592,14 @@ module {
     combine : (Key, Value, Accum) -> Accum
   ) : Accum
   {
-    var acc = base;
-    for(val in iter(rbMap, #bwd)){
-      acc := combine(val.0, val.1, acc);
-    };
-    acc
+    switch (rbMap) {
+      case (#leaf) { base };
+      case (#node(_, l, (k, v), r)) {
+        let right = foldRight(r, base, combine);
+        let middle = combine(k, v, right);
+        foldRight(l, middle, combine)
+      }
+    }
   };
 
 

--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -615,19 +615,15 @@ module {
     };
 
     public func mapFilter<K, V1, V2>(t : Map<K, V1>, compare : (K, K) -> O.Order, f : (K, V1) -> ?V2) : Map<K, V2>{
-      var map = #leaf : Map<K, V2>;
-      for(kv in iter(t, #fwd))
-      {
-        switch(f kv){
-          case null {};
-          case (?v1) {
-            // The keys still are monotonic, so we can
-            // merge trees using `append` and avoid compare here
-            map := put(map, compare, kv.0, v1);
+      func combine(key : K, value1 : V1, acc : Map<K, V2>) : Map<K, V2> {
+        switch (f(key, value1)){
+          case null { acc };
+          case (?value2) {
+            put(acc, compare, key, value2)
           }
         }
       };
-      map
+      foldLeft(t, #leaf, combine)
     };
 
     public func get<K, V>(t : Map<K, V>, compare : (K, K) -> O.Order, x : K) : ?V {

--- a/test/PersistentOrderedMap.test.mo
+++ b/test/PersistentOrderedMap.test.mo
@@ -31,24 +31,24 @@ func checkMap(rbMap : Map.Map<Nat, Text>) {
 };
 
 func blackDepth(node : Map.Map<Nat, Text>) : Nat {
+  func checkNode(left : Map.Map<Nat, Text>, key : Nat, right : Map.Map<Nat, Text>) : Nat {
+    checkKey(left, func(x) { x < key });
+    checkKey(right, func(x) { x > key });
+    let leftBlacks = blackDepth(left);
+    let rightBlacks = blackDepth(right);
+    assert (leftBlacks == rightBlacks);
+    leftBlacks
+  };
   switch node {
     case (#leaf) 0;
-    case (#node(color, left, (key, _), right)) {
-      checkKey(left, func(x) { x < key });
-      checkKey(right, func(x) { x > key });
-      let leftBlacks = blackDepth(left);
-      let rightBlacks = blackDepth(right);
-      assert (leftBlacks == rightBlacks);
-      switch color {
-        case (#R) {
-          assert (not isRed(left));
-          assert (not isRed(right));
-          leftBlacks
-        };
-        case (#B) {
-          leftBlacks + 1
-        }
-      }
+    case (#red(left, (key, _), right)) {
+      let leftBlacks = checkNode(left, key, right);
+      assert (not isRed(left));
+      assert (not isRed(right));
+      leftBlacks
+    };
+    case (#black(left, (key, _), right)) {
+      checkNode(left, key, right) + 1
     }
   }
 };
@@ -56,15 +56,18 @@ func blackDepth(node : Map.Map<Nat, Text>) : Nat {
 
 func isRed(node : Map.Map<Nat, Text>) : Bool {
   switch node {
-    case (#leaf) false;
-    case (#node(color, _, _, _)) color == #R
+    case (#red(_, _, _)) true;
+    case _ false
   }
 };
 
 func checkKey(node : Map.Map<Nat, Text>, isValid : Nat -> Bool) {
   switch node {
     case (#leaf) {};
-    case (#node(_, _, (key, _), _)) {
+    case (#red( _, (key, _), _)) {
+      assert (isValid(key))
+    };
+    case (#black( _, (key, _), _)) {
       assert (isValid(key))
     }
   }


### PR DESCRIPTION
Attempt to deduplicate branches where we expect the same code for #red and #black nodes.

In comparison with #18 

## Map comparison

| |binary_size|generate|max mem|batch_get 50|batch_put 50|batch_remove 50|upgrade|
|--:|--:|--:|--:|--:|--:|--:|--:|
|rbtree+100|189_877|225_155|42_540|50_045|135_367|133_686|565_657|
|persistentmap+100|187_078|205_152|42_600|72_688|125_249|126_969|440_636|
|persistentmap_baseline+100|187_086|205_152|42_600|53_474|124_854|127_364|440_282|
|rbtree+1000|189_877|3_118_490|580_948|67_516|181_375|180_396|5_409_805|
|persistentmap+1000|187_078|2_793_387|568_248|101_073|164_244|172_045|4_153_206|
|persistentmap_baseline+1000|187_086|2_793_387|568_248|72_497|164_285|172_045|4_153_206|
|rbtree+10000|189_877|51_301_049|520_428|83_465|224_135|230_257|53_866_589|
|persistentmap+10000|187_078|46_447_443|480_360|127_340|201_154|220_198|41_210_098|
|persistentmap_baseline+10000|187_086|46_447_443|480_360|90_438|201_072|220_280|41_210_098|
|rbtree+100000|189_877|606_914_881|5_200_428|98_012|270_465|276_802|698_928_540|
|persistentmap+100000|187_078|545_438_270|4_800_360|152_300|240_714|265_019|542_245_665|
|persistentmap_baseline+100000|187_086|545_438_270|4_800_360|106_504|240_673|265_060|542_245_665|
|rbtree+1000000|189_877|6_993_676_959|52_000_464|116_417|317_299|330_296|6_988_883_198|
|persistentmap+1000000|187_078|6_253_448_857|48_000_396|182_366|281_246|316_543|5_422_489_439|
|persistentmap_baseline+1000000|187_086|6_253_448_857|48_000_396|126_976|281_287|316_543|5_422_489_439|

## Persistent map API

| |size|foldLeft|foldRight|mapfilter|map|
|--:|--:|--:|--:|--:|--:|
|persistentmap|100|27_515|27_627|98_578|29_538|
|persistentmap_baseline|100|19_787|19_699|90_455|29_538|
|persistentmap|1000|245_061|245_532|1_666_607|263_679|
|persistentmap_baseline|1000|167_597|166_109|1_589_456|263_679|
|persistentmap|10000|2_418_441|2_420_292|33_852_941|2_600_540|
|persistentmap_baseline|10000|1_648_003|1_629_731|33_082_790|2_600_540|
|persistentmap|100000|127_962_604|127_968_368|401_683_875|129_765_701|
|persistentmap_baseline|100000|16_454_053|16_259_653|393_979_788|129_765_701|
|persistentmap|1000000|1_279_593_891|1_279_609_646|4_629_877_965|1_297_599_225|
|persistentmap_baseline|1000000|164_559_185|162_575_473|4_552_839_930|1_297_599_225|
