### PR TITLE
[DMS-68] Compare function calls from MapOps with direct function call

### DIFF
--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -608,7 +608,7 @@ module {
   };
 
 
-  module Internal {
+  public module Internal {
 
     public func fromIter<K, V>(i : I.Iter<(K,V)>, compare : (K, K) -> O.Order) : Map<K, V>
     {


### PR DESCRIPTION
In comparison with #18

Notice, that you should use https://github.com/serokell/canister-profiling/pull/2 to get these results.

| |binary_size|generate|max mem|batch_get 50|batch_put 50|batch_remove 50|upgrade|
|--:|--:|--:|--:|--:|--:|--:|--:|
|persistentmap+100|185_644|204_108|42_448|51_324|122_154|125_314|440_012|
|persistentmap_baseline+100|187_086|205_152|42_600|53_474|124_854|127_364|440_282|
|persistentmap+1000|185_644|2_783_302|568_096|70_347|161_544|169_995|4_152_936|
|persistentmap_baseline+1000|187_086|2_793_387|568_248|72_497|164_285|172_045|4_153_206|
|persistentmap+10000|185_644|46_344_787|480_208|88_288|198_372|218_189|41_209_910|
|persistentmap_baseline+10000|187_086|46_447_443|480_360|90_438|201_072|220_280|41_210_098|
|persistentmap+100000|185_644|544_437_213|4_800_208|104_354|237_973|262_969|542_242_787|
|persistentmap_baseline+100000|187_086|545_438_270|4_800_360|106_504|240_673|265_060|542_245_665|
|persistentmap+1000000|185_644|6_243_460_715|48_000_244|124_826|278_546|314_493|5_422_485_536|
|persistentmap_baseline+1000000|187_086|6_253_448_857|48_000_396|126_976|281_287|316_543|5_422_489_439|
