### PR TITLE
[DMS-68] Inline internal functions into MapOps object

### DIFF
--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -324,27 +324,49 @@ module {
   ///
   /// Note: Full map iteration creates `O(n)` temporary objects that will be collected as garbage.
   public func iter<K, V>(rbMap : Map<K, V>, direction : Direction) : I.Iter<(K, V)> {
-    object {
-      var trees : IterRep<K, V> = ?(#tr(rbMap), null);
-      public func next() : ?(K, V) {
-        switch (direction, trees) {
-          case (_, null) { null };
-          case (_, ?(#tr(#leaf), ts)) {
-            trees := ts;
-            next()
-          };
-          case (_, ?(#xy(xy), ts)) {
-            trees := ts;
-            ?xy
-          }; // TODO: Let's float-out case on direction
-          case (#fwd, ?(#tr(#node(_, l, xy, r)), ts)) {
-            trees := ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts)));
-            next()
-          };
-          case (#bwd, ?(#tr(#node(_, l, xy, r)), ts)) {
-            trees := ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts)));
-            next()
-          }
+    switch direction {
+      case (#fwd) { iterForward(rbMap) };
+      case (#bwd) { iterBackward(rbMap) }
+    }
+  };
+
+  func iterForward<K, V>(rbMap : Map<K, V>) : I.Iter<(K, V)> = object {
+    var trees : IterRep<K, V> = ?(#tr(rbMap), null);
+    public func next() : ?(K, V) {
+      switch (trees) {
+        case (null) { null };
+        case (?(#tr(#leaf), ts)) {
+          trees := ts;
+          next()
+        };
+        case (?(#xy(xy), ts)) {
+          trees := ts;
+          ?xy
+        };
+        case (?(#tr(#node(_, l, xy, r)), ts)) {
+          trees := ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts)));
+          next()
+        }
+      }
+    }
+  };
+
+  func iterBackward<K, V>(rbMap : Map<K, V>) : I.Iter<(K, V)> = object {
+    var trees : IterRep<K, V> = ?(#tr(rbMap), null);
+    public func next() : ?(K, V) {
+      switch (trees) {
+        case (null) { null };
+        case (?(#tr(#leaf), ts)) {
+          trees := ts;
+          next()
+        };
+        case (?(#xy(xy), ts)) {
+          trees := ts;
+          ?xy
+        };
+        case (?(#tr(#node(_, l, xy, r)), ts)) {
+          trees := ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts)));
+          next()
         }
       }
     }

--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -549,11 +549,14 @@ module {
     combine : (Key, Value, Accum) -> Accum
   ) : Accum
   {
-    var acc = base;
-    for(val in iter(rbMap, #fwd)){
-      acc := combine(val.0, val.1, acc);
-    };
-    acc
+    switch (rbMap) {
+      case (#leaf) { base };
+      case (#node(_, l, (k, v), r)) {
+        let left = foldLeft(l, base, combine);
+        let middle = combine(k, v, left);
+        foldLeft(r, middle, combine)
+      }
+    }
   };
 
   /// Collapses the elements in `rbMap` into a single value by starting with `base`
@@ -589,11 +592,14 @@ module {
     combine : (Key, Value, Accum) -> Accum
   ) : Accum
   {
-    var acc = base;
-    for(val in iter(rbMap, #bwd)){
-      acc := combine(val.0, val.1, acc);
-    };
-    acc
+    switch (rbMap) {
+      case (#leaf) { base };
+      case (#node(_, l, (k, v), r)) {
+        let right = foldRight(r, base, combine);
+        let middle = combine(k, v, right);
+        foldRight(l, middle, combine)
+      }
+    }
   };
 
 

--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -615,19 +615,15 @@ module {
     };
 
     public func mapFilter<K, V1, V2>(t : Map<K, V1>, compare : (K, K) -> O.Order, f : (K, V1) -> ?V2) : Map<K, V2>{
-      var map = #leaf : Map<K, V2>;
-      for(kv in iter(t, #fwd))
-      {
-        switch(f kv){
-          case null {};
-          case (?v1) {
-            // The keys still are monotonic, so we can
-            // merge trees using `append` and avoid compare here
-            map := put(map, compare, kv.0, v1);
+      func combine(key : K, value1 : V1, acc : Map<K, V2>) : Map<K, V2> {
+        switch (f(key, value1)){
+          case null { acc };
+          case (?value2) {
+            put(acc, compare, key, value2)
           }
         }
       };
-      map
+      foldLeft(t, #leaf, combine)
     };
 
     public func get<K, V>(t : Map<K, V>, compare : (K, K) -> O.Order, x : K) : ?V {


### PR DESCRIPTION
In comparison with #14 

| |binary_size|generate|max mem|batch_get 50|batch_put 50|batch_remove 50|upgrade|
|--:|--:|--:|--:|--:|--:|--:|--:|
|persistentmap+100|187_612|229_432|45_696|49_895|139_320|135_241|512_535|
|persistentmap_baseline+100|187_490|226_832|45_672|49_945|139_070|134_191|512_457|
|persistentmap+1000|187_612|3_159_881|612_904|67_366|184_367|182_741|4_878_566|
|persistentmap_baseline+1000|187_490|3_133_922|612_880|67_416|184_117|181_732|4_878_488|
|persistentmap+10000|187_612|51_699_440|520_384|83_315|227_544|232_166|48_561_185|
|persistentmap_baseline+10000|187_490|51_438_500|520_360|83_365|227_294|231_116|48_561_107|
|persistentmap+100000|187_612|610_758_920|5_200_384|97_862|273_806|278_711|645_877_257|
|persistentmap_baseline+100000|187_490|608_157_242|5_200_360|97_912|273_597|277_661|645_876_276|
|persistentmap+1000000|187_612|7_031_191_231|52_000_420|116_267|320_568|332_246|6_458_380_312|
|persistentmap_baseline+1000000|187_490|7_005_190_168|52_000_396|116_317|320_359|331_196|6_458_379_331|
