### PR TITLE
[DMS-68] Move leaf branch to the end of switch expression, as the most unlikely

### DIFF
--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -468,13 +468,13 @@ module {
   public func map<K, V1, V2>(rbMap : Map<K, V1>, f : (K, V1) -> V2) : Map<K, V2> {
     func mapRec(m : Map<K, V1>) : Map<K, V2> {
       switch m {
-        case (#leaf) { #leaf };
         case (#red(l, xy, r)) {
           #red(mapRec l, (xy.0, f xy), mapRec r)
         };
         case (#black(l, xy, r)) {
           #black(mapRec l, (xy.0, f xy), mapRec r)
         };
+        case (#leaf) { #leaf }
       }
     };
     mapRec(rbMap)
@@ -501,13 +501,13 @@ module {
   /// where `n` denotes the number of key-value entries stored in the tree.
   public func size<K, V>(t : Map<K, V>) : Nat {
     switch t {
-      case (#leaf) { 0 };
       case (#red(l, _, r)) {
         size(l) + size(r) + 1
       };
       case (#black(l, _, r)) {
         size(l) + size(r) + 1
-      }
+      };
+      case (#leaf) { 0 }
     }
   };
 
@@ -545,7 +545,6 @@ module {
   ) : Accum
   {
     switch (rbMap) {
-      case (#leaf) { base };
       case (#red(l, (k, v), r)) {
         let left = foldLeft(l, base, combine);
         let middle = combine(k, v, left);
@@ -555,7 +554,8 @@ module {
         let left = foldLeft(l, base, combine);
         let middle = combine(k, v, left);
         foldLeft(r, middle, combine)
-      }
+      };
+      case (#leaf) { base }
     }
   };
 
@@ -593,7 +593,6 @@ module {
   ) : Accum
   {
     switch (rbMap) {
-      case (#leaf) { base };
       case (#red(l, (k, v), r)) {
         let right = foldRight(r, base, combine);
         let middle = combine(k, v, right);
@@ -603,7 +602,8 @@ module {
         let right = foldRight(r, base, combine);
         let middle = combine(k, v, right);
         foldRight(l, middle, combine)
-      }
+      };
+      case (#leaf) { base }
     }
   };
 
@@ -633,7 +633,6 @@ module {
 
     public func get<K, V>(t : Map<K, V>, compare : (K, K) -> O.Order, x : K) : ?V {
       switch t {
-        case (#leaf) { null };
         case (#red(l, xy, r)) {
           switch (compare(x, xy.0)) {
             case (#less) { get(l, compare, x) };
@@ -647,7 +646,8 @@ module {
             case (#equal) { ?xy.1 };
             case (#greater) { get(r, compare, x) }
           }
-        }
+        };
+        case (#leaf) { null }
       }
     };
 
@@ -714,9 +714,6 @@ module {
     : Map<K, V>{
       func ins(tree : Map<K,V>) : Map<K,V> {
         switch tree {
-          case (#leaf) {
-            #red(#leaf, (key,val), #leaf)
-          };
           case (#black(left, xy, right)) {
             switch (compare (key, xy.0)) {
               case (#less) {
@@ -744,6 +741,9 @@ module {
                 #red(left, (key,newVal), right)
               }
             }
+          };
+          case (#leaf) {
+            #red(#leaf, (key,val), #leaf)
           }
         };
       };
@@ -903,14 +903,14 @@ module {
       };
       func del(tree : Map<K,V>) : Map<K,V> {
         switch tree {
-          case (#leaf) {
-            tree
-          };
           case (#red(left, xy, right)) {
             delNode(left, xy, right)
           };
           case (#black(left, xy, right)) {
             delNode(left, xy, right)
+          };
+          case (#leaf) {
+            tree
           }
         };
       };


### PR DESCRIPTION
In comparison with #20

## Map comparison

| |binary_size|generate|max mem|batch_get 50|batch_put 50|batch_remove 50|
|--:|--:|--:|--:|--:|--:|--:|
|persistentmap_100|187_092|201_602|42_600|51_044|122_234|124_817|
|persistentmap_baseline_100|187_086|205_152|42_600|53_474|124_854|127_364|
|persistentmap_1000|187_092|2_724_937|568_248|68_227|160_005|168_031|
|persistentmap_baseline_1000|187_086|2_793_387|568_248|72_497|164_285|172_045|
|persistentmap_10000|187_092|45_412_473|480_360|84_528|195_152|214_853|
|persistentmap_baseline_10000|187_086|46_447_443|480_360|90_438|201_072|220_280|
|persistentmap_100000|187_092|531_616_890|4_800_360|98_864|233_003|258_058|
|persistentmap_baseline_100000|187_086|545_438_270|4_800_360|106_504|240_673|265_060|
|persistentmap_1000000|187_092|6_080_971_407|48_000_396|117_446|271_877|307_984|
|persistentmap_baseline_1000000|187_086|6_253_448_857|48_000_396|126_976|281_287|316_543|

## Persistent map API

| |size|foldLeft|foldRight|mapfilter|map|
|--:|--:|--:|--:|--:|--:|
|persistentmap|100|20_807|20_719|90_125|30_759|
|persistentmap_baseline|100|19_787|19_699|90_455|29_538|
|persistentmap|1000|177_617|176_129|1_559_586|275_700|
|persistentmap_baseline|1000|167_597|166_109|1_589_456|263_679|
|persistentmap|10000|1_748_023|1_729_751|32_516_350|2_720_561|
|persistentmap_baseline|10000|1_648_003|1_629_731|33_082_790|2_600_540|
|persistentmap|100000|17_454_073|17_259_673|385_771_828|130_965_722|
|persistentmap_baseline|100000|16_454_053|16_259_653|393_979_788|129_765_701|
|persistentmap|1000000|174_559_205|172_575_493|4_445_968_980|1_309_599_246|
|persistentmap_baseline|1000000|164_559_185|162_575_473|4_552_839_930|1_297_599_225|
