### PR TITLE
[DMS-68] Use wildcard matches to avoid match on #leaf

### DIFF
--- a/src/PersistentOrderedMap.mo
+++ b/src/PersistentOrderedMap.mo
@@ -468,13 +468,13 @@ module {
   public func map<K, V1, V2>(rbMap : Map<K, V1>, f : (K, V1) -> V2) : Map<K, V2> {
     func mapRec(m : Map<K, V1>) : Map<K, V2> {
       switch m {
-        case (#leaf) { #leaf };
         case (#red(l, xy, r)) {
           #red(mapRec l, (xy.0, f xy), mapRec r)
         };
         case (#black(l, xy, r)) {
           #black(mapRec l, (xy.0, f xy), mapRec r)
         };
+        case _ { #leaf };
       }
     };
     mapRec(rbMap)
@@ -507,7 +507,7 @@ module {
       case (#black(l, _, r)) {
         size(l) + size(r) + 1
       };
-      case (#leaf) { 0 }
+      case _ { 0 }
     }
   };
 
@@ -545,7 +545,6 @@ module {
   ) : Accum
   {
     switch (rbMap) {
-      case (#leaf) { base };
       case (#red(l, (k, v), r)) {
         let left = foldLeft(l, base, combine);
         let middle = combine(k, v, left);
@@ -555,7 +554,8 @@ module {
         let left = foldLeft(l, base, combine);
         let middle = combine(k, v, left);
         foldLeft(r, middle, combine)
-      }
+      };
+      case _ { base };
     }
   };
 
@@ -593,7 +593,6 @@ module {
   ) : Accum
   {
     switch (rbMap) {
-      case (#leaf) { base };
       case (#red(l, (k, v), r)) {
         let right = foldRight(r, base, combine);
         let middle = combine(k, v, right);
@@ -603,7 +602,8 @@ module {
         let right = foldRight(r, base, combine);
         let middle = combine(k, v, right);
         foldRight(l, middle, combine)
-      }
+      };
+      case _ { base };
     }
   };
 
@@ -647,7 +647,7 @@ module {
             case (#greater) { get(r, compare, x) }
           }
         };
-        case (#leaf) { null }
+        case _ { null }
       }
     };
 
@@ -742,7 +742,7 @@ module {
               }
             }
           };
-          case (#leaf) {
+          case _ {
             #red(#leaf, (key,val), #leaf)
           }
         };
@@ -909,7 +909,7 @@ module {
           case (#black(left, xy, right)) {
             delNode(left, xy, right)
           };
-          case (#leaf) {
+          case _ {
             tree
           }
         };


### PR DESCRIPTION
In comparison with #24

## Map comparison

| |binary_size|generate|max mem|batch_get 50|batch_put 50|batch_remove 50|
|--:|--:|--:|--:|--:|--:|--:|
|persistentmap_100|186_740|200_347|42_600|50_894|121_522|124_752|
|persistentmap_baseline_100|187_090|201_602|42_600|51_044|122_234|124_817|
|persistentmap_1000|186_740|2_709_092|568_248|68_177|159_127|167_887|
|persistentmap_baseline_1000|187_090|2_724_937|568_248|68_227|160_005|168_031|
|persistentmap_10000|186_740|45_218_976|480_360|84_628|194_110|214_703|
|persistentmap_baseline_10000|187_090|45_412_473|480_360|84_528|195_152|214_853|
|persistentmap_100000|186_740|529_334_752|4_800_360|99_064|231_786|257_833|
|persistentmap_baseline_100000|187_090|531_616_890|4_800_360|98_864|233_003|258_058|
|persistentmap_1000000|186_740|6_054_723_662|48_000_396|117_796|270_486|307_736|
|persistentmap_baseline_1000000|187_090|6_080_971_407|48_000_396|117_446|271_877|307_984|

## Persistent map API

| |size|foldLeft|foldRight|mapfilter|map|
|--:|--:|--:|--:|--:|--:|
|persistentmap|100|20_058|19_970|88_863|30_010|
|persistentmap_baseline|100|19_787|19_699|89_105|29_538|
|persistentmap|1000|170_269|168_781|1_543_938|268_352|
|persistentmap_baseline|1000|167_597|166_109|1_549_566|263_679|
|persistentmap|10000|1_674_629|1_656_357|32_331_301|2_647_167|
|persistentmap_baseline|10000|1_648_003|1_629_731|32_416_330|2_600_540|
|persistentmap|100000|16_719_581|16_525_181|383_664_846|130_231_230|
|persistentmap_baseline|100000|16_454_053|16_259_653|384_771_808|129_765_701|
|persistentmap|1000000|167_215_393|165_231_681|4_422_431_384|1_302_255_434|
|persistentmap_baseline|1000000|164_559_185|162_575_473|4_435_968_960|1_297_599_225|
